### PR TITLE
Update documentation with LSP setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,21 @@ redirections (`>`, `>>`, `<`, `2>`, `&>`), and command substitution syntax are a
 
 You can customize colors via **Settings → Editor → Color Scheme → Fish**.
 
-### Code Intelligence
+### Code Intelligence (via fish-lsp)
 
-The plugin offers code completion for keywords, builtins, and user-defined functions. You can navigate to function
-definitions with Ctrl+Click using the go to definition feature. The find usages feature allows you to find all
-references to a function. Quick documentation is available on hover for builtins, keywords, operators, and variables,
-including detailed documentation for subcommands of `string`, `status`, `path`, and `history`.
+When [fish-lsp](https://github.com/ndonfris/fish-lsp) is installed, the plugin provides advanced code intelligence:
+
+- Context-aware code completion for functions, variables, commands, and arguments.
+- Go to definition for functions and variables with Ctrl+Click.
+- Find all usages of a function or variable across your workspace.
+- Hover documentation for builtins, functions, and variables.
+- Real-time diagnostics for error detection and warnings.
+- Code actions with quick fixes and refactoring suggestions.
+- Safe rename refactoring across files.
+- Code formatting via fish-lsp.
+
+Without fish-lsp, the plugin still provides basic code completion for keywords and builtins, plus quick documentation
+for Fish language elements.
 
 ### Navigation and Structure
 
@@ -33,9 +42,10 @@ matching parentheses, braces, and brackets.
 
 ### Editing Support
 
-You can toggle comments with `Ctrl+/` or `Cmd+/`. Code formatting is available via `fish_indent` when it is installed on
-your system. Run configurations allow you to execute Fish scripts directly from the IDE. A run gutter icon appears next
-to scripts for quick execution.
+You can toggle comments with `Ctrl+/` or `Cmd+/`. Code formatting is available via fish-lsp when installed. Run
+configurations allow you to execute Fish scripts directly from the IDE. A run gutter icon appears next to scripts for
+quick execution. Live templates provide snippets for common Fish constructs like functions, loops, and conditionals.
+Color preview shows inline color swatches for `set_color` commands.
 
 ### Code Quality
 
@@ -55,8 +65,19 @@ open **Settings → Plugins → ⚙️ → Install Plugin from Disk...** and sel
 
 ## Requirements
 
-The plugin requires IntelliJ IDEA 2024.3 or later, or any compatible JetBrains IDE. For code formatting, `fish_indent`
-must be available in your system PATH.
+The plugin requires IntelliJ IDEA 2024.3 or later, or any compatible JetBrains IDE.
+
+### fish-lsp (Recommended)
+
+For full code intelligence features, install [fish-lsp](https://github.com/ndonfris/fish-lsp#installation). The plugin
+will automatically detect fish-lsp if it's in your PATH, or you can configure the path manually in **Settings → Tools →
+Fish Shell**.
+
+### LSP4IJ Plugin (Community Edition)
+
+If you're using a Community Edition IDE (IntelliJ IDEA Community, PyCharm Community, etc.), you need to install the
+[LSP4IJ plugin](https://plugins.jetbrains.com/plugin/23257-lsp4ij) for LSP support. Ultimate editions have built-in LSP
+support.
 
 ## File Association
 
@@ -69,9 +90,10 @@ as `#!/usr/bin/env fish` or `#!/usr/bin/fish`.
 
 You can customize syntax highlighting colors at **Settings → Editor → Color Scheme → Fish**.
 
-### External Formatter
+### fish-lsp Settings
 
-The plugin uses `fish_indent` for code formatting. Ensure Fish is installed and `fish_indent` is available in your PATH.
+Configure fish-lsp at **Settings → Tools → Fish Shell**. You can specify a custom path to the fish-lsp executable if
+it's not in your PATH, or toggle LSP features on/off.
 
 ## Known Limitations
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -13,41 +13,32 @@
     <p>Comprehensive language support for <a href="https://fishshell.com/">Fish shell</a> scripts with advanced IDE features.</p>
 
     <h3>Syntax Highlighting</h3>
-    <ul>
-        <li>Keywords, variables, strings, comments, operators</li>
-        <li>Redirections and command substitution</li>
-        <li>Customizable color schemes</li>
-    </ul>
+    <p>Rich highlighting for keywords, variables, strings, comments, operators, redirections, and command substitution with customizable color schemes.</p>
 
     <h3>Code Intelligence (via fish-lsp)</h3>
+    <p>When <a href="https://github.com/ndonfris/fish-lsp">fish-lsp</a> is installed, the plugin provides:</p>
     <ul>
-        <li>Code completion with context-aware suggestions</li>
-        <li>Go to definition for functions and variables</li>
-        <li>Find references across workspace</li>
-        <li>Hover documentation</li>
-        <li>Diagnostics and code actions</li>
-        <li>Rename refactoring</li>
+        <li>Context-aware code completion for functions, variables, and commands.</li>
+        <li>Go to definition and find references across your workspace.</li>
+        <li>Hover documentation and real-time diagnostics.</li>
+        <li>Code actions, quick fixes, and rename refactoring.</li>
     </ul>
 
     <h3>Navigation & Structure</h3>
-    <ul>
-        <li>Structure view with function navigation</li>
-        <li>Breadcrumbs navigation</li>
-        <li>Code folding for functions and control structures</li>
-        <li>Brace matching</li>
-    </ul>
+    <p>Structure view for function navigation, breadcrumbs, code folding for functions and control structures, and brace matching.</p>
 
     <h3>Editing Support</h3>
-    <ul>
-        <li>Comment/uncomment with Ctrl+/</li>
-        <li>Code formatting via fish-lsp</li>
-        <li>Run configurations to execute scripts</li>
-        <li>Run gutter icon for quick script execution</li>
-    </ul>
+    <p>Comment toggling with Ctrl+/, code formatting via fish-lsp, run configurations, run gutter icons, live templates for common constructs, and color preview for <code>set_color</code> commands.</p>
 
-    <h3>Requirements</h3>
-    <p>For code intelligence features, install <a href="https://github.com/ndonfris/fish-lsp#installation">fish-lsp</a>.</p>
-    <p>Community Edition users need the <a href="https://plugins.jetbrains.com/plugin/23257-lsp4ij">LSP4IJ plugin</a>.</p>
+    <h3>Code Quality</h3>
+    <p>Inspections for deprecated Fish syntax and unused local variables.</p>
+
+    <h3>File Recognition</h3>
+    <p>Automatically recognizes <code>.fish</code> files and scripts with Fish shebang (<code>#!/usr/bin/env fish</code>).</p>
+
+    <h3>Setup</h3>
+    <p>For full code intelligence, <a href="https://github.com/ndonfris/fish-lsp#installation">install fish-lsp</a>. The plugin auto-detects fish-lsp in PATH, or configure it in <b>Settings → Tools → Fish Shell</b>.</p>
+    <p>Community Edition users need the <a href="https://plugins.jetbrains.com/plugin/23257-lsp4ij">LSP4IJ plugin</a> for LSP support. Ultimate editions have built-in LSP support.</p>
     ]]></description>
 
     <depends>com.intellij.modules.platform</depends>


### PR DESCRIPTION
## Summary
- Document fish-lsp integration for code intelligence in README
- Add installation instructions: `npm install -g fish-lsp`
- Document LSP4IJ requirement for Community Edition users
- Add setup section to plugin marketplace description
- Include Settings path for fish-lsp configuration