### PR TITLE
Add signing and publishing configuration for JetBrains Marketplace

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,14 @@ intellijPlatform {
             untilBuild = provider { null }
         }
     }
+    signing {
+        certificateChain = providers.environmentVariable("CERTIFICATE_CHAIN")
+        privateKey = providers.environmentVariable("PRIVATE_KEY")
+        password = providers.environmentVariable("PRIVATE_KEY_PASSWORD")
+    }
+    publishing {
+        token = providers.environmentVariable("PUBLISH_TOKEN")
+    }
     pluginVerification {
         ides {
             recommended()


### PR DESCRIPTION
- Add signing configuration to read certificate chain, private key, and password from environment variables.
- Add publishing configuration to read token from environment variable.

This fixes the release workflow failure where `'token' property must be specified for plugin publishing`.