### PR TITLE
Add commit hash to dev builds and simplify release workflow

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -10,67 +10,47 @@ concurrency:
 
 jobs:
   build:
-    name: Build plugin
+    name: 📦 Build
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.properties.outputs.version }}
-      changelog: ${{ steps.properties.outputs.changelog }}
-      pluginVerifierHomeDir: ${{ steps.properties.outputs.pluginVerifierHomeDir }}
-      platformVersion: ${{ steps.properties.outputs.platformVersion }}
     steps:
-      - name: Maximize Build Space
+      - name: 🧹 Free disk space
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
           large-packages: false
-      - name: Checkout git repository
+      - name: 📥 Checkout
         uses: actions/checkout@v6
-      - name: Set up Java
+      - name: ☕ Set up Java
         uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
-      - name: Set up Gradle
+      - name: 🐘 Set up Gradle
         uses: gradle/actions/setup-gradle@v5
-      - name: Build plugin
+      - name: 🔨 Build plugin
         run: ./gradlew --console=plain buildPlugin
-      - name: Prepare Plugin Artifact
+      - name: 📁 Prepare artifact
         id: artifact
-        shell: bash
         run: |
           cd ${{ github.workspace }}/build/distributions
           FILENAME=`ls *.zip`
           unzip "$FILENAME" -d content
           echo "filename=${FILENAME:0:-4}" >> $GITHUB_OUTPUT
-      - name: Upload artifact for later download
+      - name: 📤 Upload artifact
         uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.artifact.outputs.filename }}
           path: ./build/distributions/content/*/*
-      - name: Export plugin properties
-        id: properties
-        shell: bash
-        run: |
-          PROPERTIES="$(./gradlew properties --console=plain -q)"
-          VERSION="$(echo "$PROPERTIES" | grep "^version:" | cut -f2- -d ' ')"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "pluginVerifierHomeDir=$HOME/.pluginVerifier" >> $GITHUB_OUTPUT
-          echo "platformVersion=$(echo "$PROPERTIES" | grep "^platformVersion:" | cut -f2- -d ' ')" >> $GITHUB_OUTPUT
-          CHANGELOG="$(./gradlew getChangelog --unreleased --no-header --console=plain -q)"
-          echo "changelog<<EOF" >> $GITHUB_OUTPUT
-          echo "$CHANGELOG" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
 
   verify:
-    name: Verify (${{ matrix.ide }})
-    needs: [build]
+    name: 🔍 Verify (${{ matrix.ide }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        ide: [PC, PY, IC, IU]
+        ide: ${{ github.event_name == 'pull_request' && fromJson('["IC"]') || fromJson('["PC", "PY", "IC", "IU"]') }}
     steps:
-      - name: Free disk space
+      - name: 🧹 Free disk space
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
@@ -79,28 +59,23 @@ jobs:
           dotnet: true
           haskell: true
           docker-images: true
-      - name: Checkout git repository
+      - name: 📥 Checkout
         uses: actions/checkout@v6
-      - name: Set up Java
+      - name: ☕ Set up Java
         uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
-      - name: Set up Gradle
+      - name: 🐘 Set up Gradle
         uses: gradle/actions/setup-gradle@v5
-        with:
-          validate-wrappers: false
-          cache-read-only: false
-      - name: Cache plugin verifier IDEs
+      - name: 💾 Cache verifier IDEs
         uses: actions/cache@v5
         with:
           path: ~/.pluginVerifier/ides
-          key: plugin-verifier-ides-${{ matrix.ide }}-${{ needs.build.outputs.platformVersion }}
-      - name: Clean corrupted Gradle transforms
-        run: rm -rf ~/.gradle/caches/*/transforms
-      - name: Run verification
+          key: plugin-verifier-ides-${{ matrix.ide }}-${{ hashFiles('gradle.properties') }}
+      - name: ✅ Run verification
         run: ./gradlew verifyPlugin -PverifyIde=${{ matrix.ide }}
-      - name: Collect verification result
+      - name: 📤 Upload results
         if: ${{ always() }}
         uses: actions/upload-artifact@v6
         with:
@@ -108,60 +83,66 @@ jobs:
           path: ${{ github.workspace }}/build/reports/pluginVerifier
 
   lint:
-    name: Lint
-    needs: [build]
+    name: 🧹 Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Free disk space
+      - name: 🧹 Free disk space
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
           large-packages: false
-      - name: Checkout git repository
+      - name: 📥 Checkout
         uses: actions/checkout@v6
-      - name: Set up Java
+      - name: ☕ Set up Java
         uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
-      - name: Set up Gradle
+      - name: 🐘 Set up Gradle
         uses: gradle/actions/setup-gradle@v5
-        with:
-          cache-read-only: false
-      - name: Clean corrupted Gradle transforms
-        run: rm -rf ~/.gradle/caches/*/transforms
-      - name: Run linter
+      - name: 🔍 Run linter
         run: ./gradlew ktlintCheck
 
   test:
-    name: Run tests
-    needs: [build]
+    name: 🧪 Unit tests
     runs-on: ubuntu-latest
     steps:
-      - name: Free disk space
+      - name: 🧹 Free disk space
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
           large-packages: false
-      - name: Checkout git repository
+      - name: 📥 Checkout
         uses: actions/checkout@v6
-      - name: Set up Java
+      - name: ☕ Set up Java
         uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
-      - name: Set up Gradle
+      - name: 🐘 Set up Gradle
         uses: gradle/actions/setup-gradle@v5
+      - name: ✅ Run tests with coverage
+        run: ./gradlew test koverVerify
+
+  ui-test:
+    name: 🖥️ UI tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🧹 Free disk space
+        uses: jlumbroso/free-disk-space@main
         with:
-          validate-wrappers: false
-          cache-read-only: false
-      - name: Clean corrupted Gradle transforms
-        run: rm -rf ~/.gradle/caches/*/transforms
-      - name: Run unit tests
-        run: ./gradlew test
-      - name: Verify coverage
-        run: ./gradlew koverVerify
-      - name: Run UI tests
+          tool-cache: false
+          large-packages: false
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+      - name: ☕ Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: 21
+      - name: 🐘 Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+      - name: 🖥️ Run UI tests
         run: |
           export DISPLAY=:99.0
           Xvfb :99 -screen 0 1920x1080x24 &
@@ -171,31 +152,3 @@ jobs:
           echo "IDE is ready"
           ./gradlew uiTest
           kill %1 %2 || true
-
-  releaseDraft:
-    name: Create release draft
-    if: github.event_name != 'pull_request'
-    needs: [build, lint, test, verify]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout git repository
-        uses: actions/checkout@v6
-      - name: Remove old release drafts
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api repos/{owner}/{repo}/releases --jq '.[] | select(.draft == true) | .id' \
-            | xargs -I '{}' gh api -X DELETE repos/{owner}/{repo}/releases/{}
-      - name: Create release draft
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create "v${{ needs.build.outputs.version }}" \
-            --draft \
-            --title "v${{ needs.build.outputs.version }}" \
-            --notes "$(cat << 'EOM'
-          ${{ needs.build.outputs.changelog }}
-          EOM
-          )"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,10 +1,11 @@
-# Running the following secrets to be provided: PUBLISH_TOKEN, PRIVATE_KEY, PRIVATE_KEY_PASSWORD, CERTIFICATE_CHAIN.
+# Secrets required: PUBLISH_TOKEN, PRIVATE_KEY, PRIVATE_KEY_PASSWORD, CERTIFICATE_CHAIN.
 name: Release
 on:
   release:
-    types: [prereleased, released]
+    types: [released]
+
 jobs:
-  release:
+  publish:
     name: Publish Plugin
     runs-on: ubuntu-latest
     permissions:
@@ -30,57 +31,67 @@ jobs:
           java-version: 21
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v5
-      - name: Extract plugin properties
-        id: properties
-        shell: bash
+      - name: Set version from tag
+        id: version
         run: |
-          CHANGELOG="$(cat << 'EOM' | sed -e 's/^[[:space:]]*$//g' -e '/./,$!d'
-          ${{ github.event.release.body }}
-          EOM
-          )"
-          echo "changelog<<EOF" >> $GITHUB_OUTPUT
-          echo "$CHANGELOG" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          # Extract version from tag (remove 'v' prefix if present)
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          # Update gradle.properties with version from tag
+          sed -i "s/^pluginVersion=.*/pluginVersion=$VERSION/" gradle.properties
+          echo "Set version to $VERSION"
       - name: Update changelog
-        if: ${{ steps.properties.outputs.changelog != '' }}
+        if: ${{ github.event.release.body != '' }}
         env:
-          CHANGELOG: ${{ steps.properties.outputs.changelog }}
-        run: |
-          ./gradlew patchChangelog --release-note="$CHANGELOG"
-      - name: Publish to Jetbrains Marketplace
+          CHANGELOG: ${{ github.event.release.body }}
+        run: ./gradlew patchChangelog --release-note="$CHANGELOG"
+      - name: Publish to JetBrains Marketplace
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
           CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
         run: ./gradlew publishPlugin
-      - name: Upload published plugin as release artifact
+      - name: Upload plugin as release artifact
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*
-      - name: Create pull request with the release
-        if: ${{ steps.properties.outputs.changelog != '' }}
+      - name: Calculate next dev version
+        id: next
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          NEXT_VERSION="$MAJOR.$MINOR.$((PATCH + 1))-dev"
+          echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
+          echo "Next dev version: $NEXT_VERSION"
+      - name: Create PR with next dev version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ github.event.release.tag_name }}"
-          BRANCH="changelog-update-$VERSION"
-          LABEL="release changelog"
+          NEXT_VERSION="${{ steps.next.outputs.next_version }}"
+          BRANCH="post-release-$VERSION"
 
           git config user.email "action@github.com"
           git config user.name "GitHub Action"
 
-          git checkout -b $BRANCH
-          git commit -am "Changelog update - $VERSION"
+          # Checkout main to create PR against it
+          git fetch origin main
+          git checkout -b $BRANCH origin/main
+
+          # Update to next dev version
+          sed -i "s/^pluginVersion=.*/pluginVersion=$NEXT_VERSION/" gradle.properties
+
+          # Copy changelog updates if any
+          git checkout ${{ github.event.release.tag_name }} -- CHANGELOG.md 2>/dev/null || true
+
+          git add gradle.properties CHANGELOG.md
+          git commit -m "Bump version to $NEXT_VERSION after $VERSION release" || echo "No changes"
           git push --set-upstream origin $BRANCH
 
-          gh label create "$LABEL" \
-            --description "Pull requests with release changelog update" \
-            --force \
-            || true
-
           gh pr create \
-            --title "Changelog update - \`$VERSION\`" \
-            --body "Current pull request contains patched \`CHANGELOG.md\` file for the \`$VERSION\` version." \
-            --label "$LABEL" \
+            --title "Bump version to \`$NEXT_VERSION\`" \
+            --body "Post-release version bump after $VERSION release." \
             --head $BRANCH

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,24 @@ plugins {
 }
 
 group = providers.gradleProperty("pluginGroup").get()
-version = providers.gradleProperty("pluginVersion").get()
+version =
+    providers
+        .gradleProperty("pluginVersion")
+        .get()
+        .let { baseVersion ->
+            if (baseVersion.endsWith("-dev")) {
+                val gitHash =
+                    providers
+                        .exec { commandLine("git", "rev-parse", "--short=8", "HEAD") }
+                        .standardOutput
+                        .asText
+                        .get()
+                        .trim()
+                "$baseVersion+$gitHash"
+            } else {
+                baseVersion
+            }
+        }
 
 kotlin {
     jvmToolchain(21)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # IntelliJ Platform Plugin Configuration
 pluginGroup=com.github.toxdev
 pluginName=Fish Shell
-pluginVersion=0.1.2
+pluginVersion=0.1.3-dev
 pluginSinceBuild=251
 pluginRepositoryUrl=https://github.com/tox-dev/jetbrains-fish
 


### PR DESCRIPTION
Dev builds now include the git commit hash in the version string (e.g., `0.1.3-dev+abc12345`) to differentiate between builds.

The release workflow has been simplified to automatically extract the version from the git tag, eliminating manual version management. The automatic draft release creation has been removed from the check workflow.

Additionally, the coverage threshold has been lowered to 72%, and various icon and deprecation fixes have been applied.