### PR TITLE
Fix internal API usage, improve UI tests, add auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,18 @@
+name: Auto-merge
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  auto-merge:
+    name: 🤝 Auto-merge
+    runs-on: ubuntu-latest
+    if: |
+      (github.actor == 'gaborbernat' || github.actor == 'dependabot[bot]' || github.actor == 'pre-commit-ci[bot]')
+      && vars.AUTO_MERGE_ENABLED == 'true'
+    steps:
+      - name: 🔀 Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}

--- a/src/main/kotlin/com/github/toxdev/fish/run/FishRunProgramRunner.kt
+++ b/src/main/kotlin/com/github/toxdev/fish/run/FishRunProgramRunner.kt
@@ -1,16 +1,16 @@
 package com.github.toxdev.fish.run
 
-import com.intellij.execution.ExecutionException
-import com.intellij.execution.ExecutionManager
 import com.intellij.execution.configurations.RunProfile
+import com.intellij.execution.configurations.RunProfileState
 import com.intellij.execution.configurations.RunnerSettings
 import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.execution.runners.ExecutionEnvironment
-import com.intellij.execution.runners.ProgramRunner
-import com.intellij.execution.runners.showRunContent
+import com.intellij.execution.runners.GenericProgramRunner
+import com.intellij.execution.runners.RunContentBuilder
+import com.intellij.execution.ui.RunContentDescriptor
 import com.intellij.openapi.fileEditor.FileDocumentManager
 
-class FishRunProgramRunner : ProgramRunner<RunnerSettings> {
+class FishRunProgramRunner : GenericProgramRunner<RunnerSettings>() {
     override fun getRunnerId(): String = "fishRunRunner"
 
     override fun canRun(
@@ -18,11 +18,12 @@ class FishRunProgramRunner : ProgramRunner<RunnerSettings> {
         profile: RunProfile,
     ): Boolean = DefaultRunExecutor.EXECUTOR_ID == executorId && profile is FishRunConfiguration
 
-    @Throws(ExecutionException::class)
-    override fun execute(environment: ExecutionEnvironment) {
-        ExecutionManager.getInstance(environment.getProject()).startRunProfile(environment) { state ->
-            FileDocumentManager.getInstance().saveAllDocuments()
-            showRunContent(state.execute(environment.executor, this), environment)
-        }
+    override fun doExecute(
+        state: RunProfileState,
+        environment: ExecutionEnvironment,
+    ): RunContentDescriptor? {
+        FileDocumentManager.getInstance().saveAllDocuments()
+        val result = state.execute(environment.executor, this) ?: return null
+        return RunContentBuilder(result, environment).showRunContent(environment.contentToReuse)
     }
 }

--- a/src/test/kotlin/com/github/toxdev/fish/UITest.kt
+++ b/src/test/kotlin/com/github/toxdev/fish/UITest.kt
@@ -121,8 +121,15 @@ class UITest {
                 found.first().doubleClick()
                 waitFor(ofSeconds(10)) { isDumbMode().not() }
             }
-            waitFor(ofSeconds(10)) {
-                editorTabs.hasText("test.fish")
+            waitFor(ofSeconds(30)) {
+                try {
+                    val hasTab = editorTabs.hasText("test.fish")
+                    println("DEBUG: editorTabs.hasText('test.fish') = $hasTab")
+                    hasTab
+                } catch (e: Exception) {
+                    println("DEBUG: editorTabs not found yet: ${e.message}")
+                    false
+                }
             }
         }
     }
@@ -133,7 +140,13 @@ class UITest {
             with(projectViewTree) {
                 waitFor(ofSeconds(10)) { hasText("test.fish") }
                 findAllText("test.fish").first().doubleClick()
-                waitFor(ofSeconds(10)) { isDumbMode().not() }
+            }
+            waitFor(ofSeconds(30)) {
+                try {
+                    isDumbMode().not() && editorTabs.hasText("test.fish")
+                } catch (e: Exception) {
+                    false
+                }
             }
         }
     }


### PR DESCRIPTION
Replaces `ProgramRunner` with `GenericProgramRunner` to avoid using the internal `ExecutionManager.startRunProfile()` API that was flagged by the plugin verifier.

Improves UI test stability by increasing timeouts and adding try-catch for editor tab detection, which was causing intermittent failures in CI.

Adds an auto-merge workflow that automatically enables squash merge for PRs from trusted authors (gaborbernat, dependabot, pre-commit-ci) once all required checks pass.

Bumps version to 0.1.5-dev.