### PR TITLE
Fix auto-merge workflow to use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,18 +1,20 @@
 name: Auto-merge
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   auto-merge:
     name: 🤝 Auto-merge
     runs-on: ubuntu-latest
-    if: |
-      (github.actor == 'gaborbernat' || github.actor == 'dependabot[bot]' || github.actor == 'pre-commit-ci[bot]')
-      && vars.AUTO_MERGE_ENABLED == 'true'
+    if: github.actor == 'gaborbernat' || github.actor == 'dependabot[bot]' || github.actor == 'pre-commit-ci[bot]' || github.actor == 'github-actions[bot]'
     steps:
       - name: 🔀 Enable auto-merge
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Now that classic branch protection is configured (replacing the ruleset), GITHUB_TOKEN has permission to enable auto-merge. This removes the need for a PAT and the AUTO_MERGE_ENABLED variable.