### PR TITLE
Use RELEASE_TOKEN for post-release PR to trigger workflows

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -3,10 +3,6 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   auto-merge:
     name: 🤝 Auto-merge
@@ -17,4 +13,4 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
           echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
       - name: 📝 Create post-release PR
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           VERSION="${{ github.event.release.tag_name }}"
           NEXT_VERSION="${{ steps.next.outputs.next_version }}"


### PR DESCRIPTION
PRs created with GITHUB_TOKEN don't trigger other workflows (GitHub security feature to prevent infinite loops).

Using RELEASE_TOKEN (a PAT) instead allows the post-release PR to trigger both the Build workflow and the Auto-merge workflow.