### PR TITLE
👷 ci(ui-test): fix IDE startup timeout in CI

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -142,13 +142,15 @@ jobs:
           java-version: 21
       - name: 🐘 Set up Gradle
         uses: gradle/actions/setup-gradle@v5
+      - name: 🔨 Build test IDE sandbox
+        run: ./gradlew buildPlugin compileTestKotlin
       - name: 🖥️ Run UI tests
         run: |
           export DISPLAY=:99.0
           Xvfb :99 -screen 0 1920x1080x24 &
           ./gradlew runIdeForUiTests &
           echo "Waiting for IDE to start..."
-          timeout 180 bash -c 'until curl -s http://127.0.0.1:8082 > /dev/null 2>&1; do sleep 2; done' || { echo "IDE failed to start"; exit 1; }
+          timeout 300 bash -c 'until curl -s http://127.0.0.1:8082 > /dev/null 2>&1; do sleep 2; done' || { echo "IDE failed to start"; exit 1; }
           echo "IDE is ready"
           ./gradlew uiTest
           kill %1 %2 || true

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ pluginRepositoryUrl=https://github.com/tox-dev/jetbrains-fish
 platformVersion=2025.1
 
 # Gradle settings
-gradleVersion=9.2.1
+gradleVersion=9.3.1
 org.gradle.jvmargs=-Xmx2g -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.caching=true
 org.gradle.configuration-cache=true


### PR DESCRIPTION
The UI test job has been failing consistently since run #97 because the 180-second
timeout for IDE startup included Gradle configuration, dependency resolution, and
sandbox preparation — not just the actual IDE boot. 🕐 Even in the last successful
run (#96), the IDE became ready at 173 seconds, leaving only 7 seconds of margin.
Any cold cache or dependency bump pushed it past the deadline.

The fix separates the Gradle build from IDE startup by adding a pre-build step that
runs `buildPlugin` and `compileTestKotlin` synchronously before launching `runIdeForUiTests`.
This way the timeout only covers the actual IDE boot, not artifact resolution. The timeout
is also increased from 180s to 300s as additional safety margin. ⚡ The `gradleVersion`
property is aligned with the actual wrapper version (`9.3.1`).