### PR TITLE
🐛 fix(lexer): handle escaped backslashes in single-quoted strings

### DIFF
--- a/src/main/kotlin/com/github/toxdev/fish/lexer/Fish.flex
+++ b/src/main/kotlin/com/github/toxdev/fish/lexer/Fish.flex
@@ -163,6 +163,9 @@ WORD={WP}
 }
 
 <IN_SINGLE_QUOTE> {
+    // Escaped backslash inside single-quoted string (Fish 3.0+)
+    \\\\                { return FishTypes.ESCAPE; }
+
     // Escaped single quote inside single-quoted string (Fish 3.0+)
     \\'                 { return FishTypes.ESCAPE; }
 
@@ -175,8 +178,8 @@ WORD={WP}
     // Everything else is literal content (except newlines which are handled above)
     [^\\'\r\n]+         { return FishTypes.STRING_CONTENT; }
 
-    // One or more backslashes not followed by quote are literal
-    \\+                 { return FishTypes.STRING_CONTENT; }
+    // Lone backslash not followed by another backslash or quote is literal
+    \\                  { return FishTypes.STRING_CONTENT; }
 }
 
 <IN_ANSI_QUOTE> {

--- a/src/test/kotlin/com/github/toxdev/fish/lexer/FishLexerTest.kt
+++ b/src/test/kotlin/com/github/toxdev/fish/lexer/FishLexerTest.kt
@@ -217,6 +217,63 @@ class FishLexerTest {
     }
 
     @Test
+    fun `test escaped backslashes before escaped single quote`() {
+        val input = "echo '\\\\\\''"
+        val lexer = FishLexerAdapter()
+        lexer.start(input)
+
+        val tokens = collectTokens(lexer)
+
+        assertEquals("FishTokenType.WORD", tokens[0].first, "echo")
+        assertEquals("WHITE_SPACE", tokens[1].first)
+        assertEquals("FishTokenType.SINGLE_QUOTE", tokens[2].first, "opening quote")
+        assertEquals("FishTokenType.ESCAPE", tokens[3].first, "escaped backslash \\\\")
+        assertEquals("FishTokenType.ESCAPE", tokens[4].first, "escaped single quote \\'")
+        assertEquals("FishTokenType.SINGLE_QUOTE", tokens[5].first, "closing quote")
+        assertEquals(6, tokens.size)
+    }
+
+    @Test
+    fun `test multiple escaped backslashes in single quoted string`() {
+        val input = "'\\\\\\\\'"
+        val lexer = FishLexerAdapter()
+        lexer.start(input)
+
+        val tokens = collectTokens(lexer)
+
+        assertEquals("FishTokenType.SINGLE_QUOTE", tokens[0].first, "opening quote")
+        assertEquals("FishTokenType.ESCAPE", tokens[1].first, "first escaped backslash")
+        assertEquals("FishTokenType.ESCAPE", tokens[2].first, "second escaped backslash")
+        assertEquals("FishTokenType.SINGLE_QUOTE", tokens[3].first, "closing quote")
+        assertEquals(4, tokens.size)
+    }
+
+    @Test
+    fun `test lone backslash in single quoted string`() {
+        val input = "'a\\b'"
+        val lexer = FishLexerAdapter()
+        lexer.start(input)
+
+        val tokens = collectTokens(lexer)
+
+        assertEquals("FishTokenType.SINGLE_QUOTE", tokens[0].first, "opening quote")
+        assertEquals("FishTokenType.STRING_CONTENT", tokens[1].first, "a")
+        assertEquals("FishTokenType.STRING_CONTENT", tokens[2].first, "lone backslash")
+        assertEquals("FishTokenType.STRING_CONTENT", tokens[3].first, "b")
+        assertEquals("FishTokenType.SINGLE_QUOTE", tokens[4].first, "closing quote")
+        assertEquals(5, tokens.size)
+    }
+
+    private fun collectTokens(lexer: FishLexerAdapter): List<Pair<String, String>> {
+        val tokens = mutableListOf<Pair<String, String>>()
+        while (lexer.tokenType != null) {
+            tokens.add(lexer.tokenType.toString() to lexer.tokenText)
+            lexer.advance()
+        }
+        return tokens
+    }
+
+    @Test
     fun `analyze bad characters`() {
         val badChars = mutableMapOf<Char, MutableList<String>>()
 

--- a/src/test/testData/edge_cases/single-quote-escapes.fish
+++ b/src/test/testData/edge_cases/single-quote-escapes.fish
@@ -1,0 +1,8 @@
+# Escaped backslashes before escaped single-quote in single-quoted strings
+echo '\\\''
+echo '\\\\\\\''
+echo '\\'
+echo 'no escapes'
+echo 'it\'s fine'
+echo 'back\\slash'
+echo 'end with backslash\\'


### PR DESCRIPTION
Patterns like `echo '\\\''` (escaped backslash followed by escaped single-quote) caused a parse error because the lexer's `\\+` rule greedily consumed all consecutive backslashes as `STRING_CONTENT`. This left the `\'` escape sequence broken — the `'` would close the string prematurely, and the trailing `'` started an unterminated string, producing the `FishTokenType.SINGLE_QUOTE expected` error reported in #33.

🔧 The fix adds a `\\\\` rule to the `IN_SINGLE_QUOTE` lexer state that recognizes pairs of backslashes as `ESCAPE` tokens (matching how `\\'` already handles escaped single-quotes), and changes the catch-all `\\+` to `\\` so a lone backslash can't greedily consume characters that belong to subsequent escape sequences.

Closes #33