### PR TITLE
Add permissions to workflows

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -3,6 +3,8 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+permissions: {}
+
 jobs:
   auto-merge:
     name: 🤝 Auto-merge

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: 📦 Build


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to the check workflow
- Add explicit `permissions: {}` to the auto-merge workflow (uses `secrets.RELEASE_TOKEN`, no GITHUB_TOKEN needed)
- Satisfies the `actions/missing-workflow-permissions` code scanning rule