### PR TITLE
🔧 fix(ci): restore git credentials for post-release automation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,8 +18,7 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.release.tag_name }}
-          persist-credentials: false
+          ref: ${{ github.event.release.tag_name }} # zizmor: ignore[artipacked]
       - name: 🧹 Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:


### PR DESCRIPTION
The zizmor security tool added `persist-credentials: false` to the checkout step, which broke the post-release workflow. After publishing to the JetBrains Marketplace, the job creates a version bump PR by pushing a new branch, but credential stripping caused authentication failures.

Removing `persist-credentials: false` restores the ability to push branches for automated PRs. 🔐 The `artipacked` warning is suppressed with an inline ignore because it's a false positive—this job uploads plugin distributions to GitHub releases, not artifacts containing the `.git` directory that could leak credentials.

This change only affects the release workflow. The credentials are already protected by the `release` environment requirement.