### PR TITLE
Force patched versions of vulnerable test dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,16 @@ dependencies {
     }
 }
 
+// Force patched versions of vulnerable transitive build/test dependencies (Dependabot alerts).
+// These come from the UI-test harness and JUnit test framework, not the shipped plugin.
+configurations.all {
+    resolutionStrategy.force(
+        "com.squareup.okhttp3:okhttp:4.12.0",
+        "com.squareup.okio:okio:3.9.0",
+        "org.assertj:assertj-core:3.27.7",
+    )
+}
+
 // JFlex lexer generation using Grammar-Kit plugin
 val generateFishLexer by tasks.registering(GenerateLexerTask::class) {
     sourceFile.set(file("src/main/kotlin/com/github/toxdev/fish/lexer/Fish.flex"))


### PR DESCRIPTION
okhttp, okio and assertj-core are pulled in transitively by the UI-test harness (`remoteRobot`) and the JUnit test framework — none ship in the plugin artifact — but Dependabot flags them. Force patched releases so the dependency graph is clean:

- com.squareup.okhttp3:okhttp 4.12.0 (GHSA-3cqm-mf7h-prrj)
- com.squareup.okio:okio 3.9.0 (GHSA-w33c-445m-f8w7)
- org.assertj:assertj-core 3.27.7 (GHSA-rqfh-9r24-8c9r)

The remaining jackson/logback/undertow alerts come from the IntelliJ Platform itself (provided by the IDE at runtime, not bundled) and are handled separately.