### PR TITLE
fix: stop mocking global ApplicationManager in LSP tests

### DIFF
--- a/src/test/kotlin/com/github/toxdev/fish/lsp/FishLspConfigurableTest.kt
+++ b/src/test/kotlin/com/github/toxdev/fish/lsp/FishLspConfigurableTest.kt
@@ -1,11 +1,9 @@
 package com.github.toxdev.fish.lsp
 
-import com.intellij.openapi.application.Application
-import com.intellij.openapi.application.ApplicationManager
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkStatic
+import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -14,18 +12,17 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class FishLspConfigurableTest {
-    private lateinit var application: Application
     private lateinit var settings: FishLspSettings
 
     @BeforeEach
     fun setUp() {
         clearAllMocks()
-        application = mockk(relaxed = true)
         settings = mockk(relaxed = true)
 
-        mockkStatic(ApplicationManager::class)
-        every { ApplicationManager.getApplication() } returns application
-        every { application.getService(FishLspSettings::class.java) } returns settings
+        // Mock the settings accessor directly rather than the global ApplicationManager, which would
+        // hand a relaxed mock to platform background coroutines and crash them.
+        mockkObject(FishLspSettings.Companion)
+        every { FishLspSettings.getInstance() } returns settings
         every { settings.fishLspPath } returns ""
     }
 

--- a/src/test/kotlin/com/github/toxdev/fish/lsp/FishLspSettingsTest.kt
+++ b/src/test/kotlin/com/github/toxdev/fish/lsp/FishLspSettingsTest.kt
@@ -96,9 +96,14 @@ class FishLspSettingsCompanionTest {
     @BeforeEach
     fun setUp() {
         clearAllMocks()
+        val realApplication = ApplicationManager.getApplication()
         application = mockk(relaxed = true)
         mockkStatic(ApplicationManager::class)
         every { ApplicationManager.getApplication() } returns application
+        // Delegate unmapped service lookups to the real application so platform background coroutines
+        // don't receive the relaxed mock's default return value and crash while this test holds the
+        // ApplicationManager mock. Individual tests override getService for FishLspSettings.
+        every { application.getService(any<Class<*>>()) } answers { realApplication?.getService(firstArg<Class<*>>()) }
     }
 
     @AfterEach


### PR DESCRIPTION
The `🧪 Unit tests` check fails intermittently on `main` (for example on the post-release bump #110), with `2 uncaught exceptions` in tests like `FishLspConfigurable class exists` and other LSP tests. The exceptions are `ClassCastException`s thrown from platform background coroutines (such as the local-history flusher), which the test framework rethrows and attributes to whichever test is running.

`FishLspConfigurableTest` and `FishLspSettingsCompanionTest` replaced the global `ApplicationManager` with a relaxed mock to control `FishLspSettings`. While that mock is installed, any platform background thread that calls `ApplicationManager.getApplication().getService(...)` receives the relaxed mock's default `Object` and fails casting it to the expected service, so the outcome depends on timing. `FishLspConfigurableTest` now mocks `FishLspSettings.getInstance()` directly and leaves `ApplicationManager` real. `FishLspSettingsCompanionTest` genuinely exercises the `getInstance()` service lookup, so it keeps the `ApplicationManager` mock but delegates unmapped `getService` calls to the real application, and each test still overrides the lookup for `FishLspSettings`. This mirrors the earlier fix for `FishLspNotificationFunctionTest`.
