### PR TITLE
♻️ refactor(lsp): migrate to LspIntegrationProvider API

### DIFF
--- a/src/main/kotlin/com/github/toxdev/fish/lsp/FishLspClientDescriptor.kt
+++ b/src/main/kotlin/com/github/toxdev/fish/lsp/FishLspClientDescriptor.kt
@@ -4,11 +4,11 @@ import com.github.toxdev.fish.FishFileType
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
+import com.intellij.platform.lsp.api.ProjectWideLspClientDescriptor
 
-class FishLspServerDescriptor(
+class FishLspClientDescriptor(
     project: Project,
-) : ProjectWideLspServerDescriptor(project, "Fish LSP") {
+) : ProjectWideLspClientDescriptor(project, "Fish LSP") {
     override fun isSupportedFile(file: VirtualFile): Boolean = file.fileType == FishFileType.INSTANCE
 
     override fun createCommandLine(): GeneralCommandLine {

--- a/src/main/kotlin/com/github/toxdev/fish/lsp/FishLspIntegrationProvider.kt
+++ b/src/main/kotlin/com/github/toxdev/fish/lsp/FishLspIntegrationProvider.kt
@@ -5,18 +5,18 @@ import com.github.toxdev.fish.FishIcons
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.platform.lsp.api.LspServer
-import com.intellij.platform.lsp.api.LspServerSupportProvider
-import com.intellij.platform.lsp.api.LspServerSupportProvider.LspServerStarter
-import com.intellij.platform.lsp.api.lsWidget.LspServerWidgetItem
+import com.intellij.platform.lsp.api.LspClient
+import com.intellij.platform.lsp.api.LspIntegrationProvider
+import com.intellij.platform.lsp.api.LspIntegrationProvider.LspClientStarter
+import com.intellij.platform.lsp.api.lsWidget.LspClientWidgetItem
 
-private val LOG = logger<FishLspServerSupportProvider>()
+private val LOG = logger<FishLspIntegrationProvider>()
 
-class FishLspServerSupportProvider : LspServerSupportProvider {
+class FishLspIntegrationProvider : LspIntegrationProvider {
     override fun fileOpened(
         project: Project,
         file: VirtualFile,
-        serverStarter: LspServerStarter,
+        clientStarter: LspClientStarter,
     ) {
         if (file.fileType != FishFileType.INSTANCE) return
 
@@ -27,11 +27,11 @@ class FishLspServerSupportProvider : LspServerSupportProvider {
         }
 
         LOG.info("Starting Fish LSP server for ${file.name}")
-        serverStarter.ensureServerStarted(FishLspServerDescriptor(project))
+        clientStarter.ensureClientStarted(FishLspClientDescriptor(project))
     }
 
-    override fun createLspServerWidgetItem(
-        lspServer: LspServer,
+    override fun createWidgetItem(
+        lspClient: LspClient,
         currentFile: VirtualFile?,
-    ): LspServerWidgetItem = LspServerWidgetItem(lspServer, currentFile, FishIcons.FILE, FishLspConfigurable::class.java)
+    ): LspClientWidgetItem = LspClientWidgetItem(lspClient, currentFile, FishIcons.FILE, FishLspConfigurable::class.java)
 }

--- a/src/main/resources/META-INF/fish-lsp-ultimate.xml
+++ b/src/main/resources/META-INF/fish-lsp-ultimate.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <!-- JetBrains Native LSP Support (Ultimate/Commercial IDEs) -->
     <extensions defaultExtensionNs="com.intellij.platform.lsp">
-        <serverSupportProvider
-            implementation="com.github.toxdev.fish.lsp.FishLspServerSupportProvider"/>
+        <integrationProvider
+            implementation="com.github.toxdev.fish.lsp.FishLspIntegrationProvider"/>
     </extensions>
 </idea-plugin>

--- a/src/test/kotlin/com/github/toxdev/fish/lsp/FishLspClientDescriptorTest.kt
+++ b/src/test/kotlin/com/github/toxdev/fish/lsp/FishLspClientDescriptorTest.kt
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 @TestApplication
-class FishLspServerDescriptorTest {
-    private lateinit var descriptor: FishLspServerDescriptor
+class FishLspClientDescriptorTest {
+    private lateinit var descriptor: FishLspClientDescriptor
     private lateinit var settings: FishLspSettings
 
     @BeforeEach
@@ -28,7 +28,7 @@ class FishLspServerDescriptorTest {
         every { FishLspSettings.getInstance() } returns settings
 
         val project = ProjectManager.getInstance().defaultProject
-        descriptor = FishLspServerDescriptor(project)
+        descriptor = FishLspClientDescriptor(project)
     }
 
     @AfterEach

--- a/src/test/kotlin/com/github/toxdev/fish/lsp/FishLspIntegrationProviderTest.kt
+++ b/src/test/kotlin/com/github/toxdev/fish/lsp/FishLspIntegrationProviderTest.kt
@@ -2,36 +2,36 @@ package com.github.toxdev.fish.lsp
 
 import com.github.toxdev.fish.FishFileType
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.platform.lsp.api.LspServer
+import com.intellij.platform.lsp.api.LspClient
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 
-class FishLspServerSupportProviderTest {
+class FishLspIntegrationProviderTest {
     @Test
     fun `provider is instantiable`() {
-        val provider = FishLspServerSupportProvider()
+        val provider = FishLspIntegrationProvider()
         assertNotNull(provider)
     }
 
     @Test
-    fun `createLspServerWidgetItem returns widget item`() {
-        val provider = FishLspServerSupportProvider()
-        val lspServer = mockk<LspServer>(relaxed = true)
+    fun `createWidgetItem returns widget item`() {
+        val provider = FishLspIntegrationProvider()
+        val lspClient = mockk<LspClient>(relaxed = true)
         val currentFile = mockk<VirtualFile>()
 
-        val widgetItem = provider.createLspServerWidgetItem(lspServer, currentFile)
+        val widgetItem = provider.createWidgetItem(lspClient, currentFile)
 
         assertNotNull(widgetItem)
     }
 
     @Test
-    fun `createLspServerWidgetItem with null file returns widget item`() {
-        val provider = FishLspServerSupportProvider()
-        val lspServer = mockk<LspServer>(relaxed = true)
+    fun `createWidgetItem with null file returns widget item`() {
+        val provider = FishLspIntegrationProvider()
+        val lspClient = mockk<LspClient>(relaxed = true)
 
-        val widgetItem = provider.createLspServerWidgetItem(lspServer, null)
+        val widgetItem = provider.createWidgetItem(lspClient, null)
 
         assertNotNull(widgetItem)
     }


### PR DESCRIPTION
The JetBrains Marketplace compatibility check against IntelliJ IDEA 2026.2.1 RC reported 11 deprecated API usages for Fish Shell 0.1.9, all in the native LSP integration. JetBrains renamed the LSP classes in 2026.1.4 so the IDE side reads as the client rather than the server. The [LSP documentation](https://plugins.jetbrains.com/docs/intellij/language-server-protocol.html) lists the mapping. `LspServerSupportProvider` became `LspIntegrationProvider`, `LspServerDescriptor` became `LspClientDescriptor`, `LspServer` became `LspClient`, and the extension point moved from `com.intellij.platform.lsp.serverSupportProvider` to `com.intellij.platform.lsp.integrationProvider`. The old names still work as deprecated shims, though JetBrains [plans to expose new LSP features through the new API alone](https://blog.jetbrains.com/platform/2026/06/open-sourcing-the-lsp-client-api-in-intellij-idea-2026-2/).

The migration swaps imports and renames two overrides, `createLspServerWidgetItem` to `createWidgetItem` and `ensureServerStarted` to `ensureClientStarted`. I renamed our own classes alongside the platform ones, so `FishLspServerSupportProvider` is now `FishLspIntegrationProvider` and `FishLspServerDescriptor` is now `FishLspClientDescriptor`. `pluginSinceBuild` is already `262`, so no supported platform build needs the deprecated names.

Nothing about the runtime behavior changes. `verifyPlugin -PverifyIde=IU` reports `Compatible` with no deprecation warnings. I left the LSP4IJ path that Community Edition uses alone.
